### PR TITLE
bugfix/node-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:12-alpine
 
 # drop back to the non-privileged user for run-time
 WORKDIR /home/node


### PR DESCRIPTION
## 📌 Fix node to v12 in Dockerfile

We had specified node as 'lts' in the Dockerfile, which was fine when 12
was the lts version. 14 is now the lts version, so that's not going to
work. Our 'package-lock' dependencies have some 12-vs-14 specific
bugs/versions, so API call routing and DB access goes a bit off with the
wrong versions.

We've already fixed our package.json and github actions to v12, we just
missed the Dockerfile. :(