### PR TITLE
Add read-only user to database

### DIFF
--- a/util/db/pre-migrations/20210823204733-sfo-ro-create-user.js
+++ b/util/db/pre-migrations/20210823204733-sfo-ro-create-user.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// The pre-migrations only make sense when running inside the production docker
+// environment. They are not required for the development SQLite DB.
+if (process.env.NODE_ENV === 'production') {
+  // Even though this is a 'pre-migrations' migration, we need to import the
+  // production config as we're setting the password the production account will
+  // use.
+  const config = require('../../../src/config/database.js').database;
+
+  module.exports = {
+    up: (queryInterface, Sequelize) => {
+      return queryInterface.sequelize.query('create role rosfo with noinherit login password :trapsPassword;', {
+        type: Sequelize.QueryTypes.RAW,
+        replacements: {
+          trapsPassword: config.password
+        }
+      });
+    },
+    down: (queryInterface, Sequelize) => {
+      return queryInterface.sequelize.query('drop role rosfo;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+    }
+  };
+} else {
+  module.exports = {
+    up: () => {
+      return Promise.resolve();
+    },
+    down: () => {
+      return Promise.resolve();
+    }
+  };
+}

--- a/util/db/pre-migrations/20210823204833-sfo-ro-grant-to-user.js
+++ b/util/db/pre-migrations/20210823204833-sfo-ro-grant-to-user.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// The pre-migrations only make sense when running inside the production docker
+// environment. They are not required for the development SQLite DB.
+if (process.env.NODE_ENV === 'production') {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      await queryInterface.sequelize.query('grant connect on database licensing to rosfo;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('grant usage on schema sfo to rosfo;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('grant select on all tables in schema sfo to rosfo;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query(
+        'alter default privileges for role licensing, sfo in schema sfo grant select on tables to rosfo;',
+        {
+          type: Sequelize.QueryTypes.RAW
+        }
+      );
+    },
+    down: async (queryInterface, Sequelize) => {
+      await queryInterface.sequelize.query(
+        'alter default privileges for role licensing, sfo in schema sfo revoke select on tables to rosfo;',
+        {
+          type: Sequelize.QueryTypes.RAW
+        }
+      );
+
+      await queryInterface.sequelize.query('revoke select on schema sfo from rosfo;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('revoke usage on schema sfo from rosfo;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('revoke all on database licensing from rosfo;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+    }
+  };
+} else {
+  module.exports = {
+    up: () => {
+      return Promise.resolve();
+    },
+    down: () => {
+      return Promise.resolve();
+    }
+  };
+}


### PR DESCRIPTION
Part of issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/811.

Adds a read-only user to the `sfo` database to be used by Superset.