### PR TITLE
Add migration script to drop and recreate applications view.

### DIFF
--- a/util/db/migrations/20210927064433-drop-recreate-application-view.js
+++ b/util/db/migrations/20210927064433-drop-recreate-application-view.js
@@ -1,0 +1,34 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      await queryInterface.sequelize.query('DROP VIEW sfo_applications;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('CREATE VIEW sfo_applications AS SELECT * FROM sfo."Applications";', {
+        type: Sequelize.QueryTypes.RAW
+      });
+    },
+
+    down: async (queryInterface, Sequelize) => {
+      await queryInterface.sequelize.query('DROP VIEW sfo_applications;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('CREATE VIEW sfo_applications AS SELECT * FROM sfo."Applications";', {
+        type: Sequelize.QueryTypes.RAW
+      });
+    }
+  };
+} else {
+  module.exports = {
+    up: () => {
+      return Promise.resolve();
+    },
+    down: () => {
+      return Promise.resolve();
+    }
+  };
+}


### PR DESCRIPTION
Part of issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/903.

PostgreSQL doesn't use `SELECT *` when it saves the code to create a view, but rather keeps all the column names, so the view needs to be dropped and recreated so Superset can sync with the updated view and see the new `expiryDate` column.