### PR TITLE
Add copy command for secrets folder to Dockerfile. Issue Licensing 1438

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN npm ci && npm prune
 COPY --chown=node:node ./src ./src
 COPY --chown=node:node ./util ./util
 COPY --chown=node:node .sequelizerc ./
+COPY --chown=node:node ./.secrets ./.secrets
 
 # these variables are for overriding but keep them consistent between image and
 # run


### PR DESCRIPTION
Adds a `copy` to the Dockerfile to copy across the encrypted private key to the container.