### PR TITLE
Update EC public key const with correct x and y values. Issue 1400

### DIFF
--- a/src/config/jwk.js
+++ b/src/config/jwk.js
@@ -27,10 +27,9 @@ const testKeyPair = {
  */
 const publicKey = {
   kty: 'EC',
-  kid: 'KMzSz_C_LDlN-dj7J3u9qYlpTpYtANo4unsy9pFRwqI',
   crv: 'P-256',
-  x: 'i6e0757Y7-fATWDxXQmSIsXfNjWWHhRosBvnK3RVnq8',
-  y: 'IThf8O6eI8IL6jpHfFltv9vYCFHNyy0Eb4_kfmuXlzU'
+  x: 'tJp3nHPEbYhGgqHw4M3KBhkSo1sLIk_VDHFjw0ZRo88',
+  y: '7Rb4A4VjdLpj_gAhg_aSxcP5s7On83I2hqYsIvRQxPc'
 };
 
 /**


### PR DESCRIPTION
Part of issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1400.

The public key `const` had the wrong `x` and `y` values so verification of tokens was failing.