### PR TITLE
Bugfix/unused licence create return

### DIFF
--- a/src/controllers/v2/returns.js
+++ b/src/controllers/v2/returns.js
@@ -211,7 +211,8 @@ const ReturnsController = {
       });
 
       return newReturnTransaction.id;
-    } catch {
+    } catch (error) {
+      console.log(error);
       return undefined;
     }
   }

--- a/src/controllers/v2/returns.js
+++ b/src/controllers/v2/returns.js
@@ -186,6 +186,10 @@ const ReturnsController = {
     } catch {
       return undefined;
     }
+  },
+
+  async createLicenceNotUsed (id, cleanObject) {
+
   }
 };
 

--- a/src/models/returns.js
+++ b/src/models/returns.js
@@ -22,16 +22,10 @@ const ReturnsModel = (sequelize) => {
         }
       },
       startDate: {
-        type: Sequelize.DATE,
-        validate: {
-          notEmpty: true
-        }
+        type: Sequelize.DATE
       },
       endDate: {
-        type: Sequelize.DATE,
-        validate: {
-          notEmpty: true
-        }
+        type: Sequelize.DATE
       },
       usedLicence: {
         type: Sequelize.BOOLEAN

--- a/util/db/migrations/20221007074355-remove-allow-null-false-on-return-date-columns.js
+++ b/util/db/migrations/20221007074355-remove-allow-null-false-on-return-date-columns.js
@@ -1,22 +1,26 @@
 'use strict';
 
 module.exports = {
-  async up(queryInterface) {
+  async up(queryInterface, Sequelize) {
     await queryInterface.changeColumn('Returns', 'startDate', {
+      type: Sequelize.DATE,
       allowNull: true
     });
 
     await queryInterface.changeColumn('Returns', 'endDate', {
+      type: Sequelize.DATE,
       allowNull: true
     });
   },
 
-  async down(queryInterface) {
+  async down(queryInterface, Sequelize) {
     await queryInterface.changeColumn('Returns', 'endDate', {
+      type: Sequelize.DATE,
       allowNull: false
     });
 
     await queryInterface.changeColumn('Returns', 'startDate', {
+      type: Sequelize.DATE,
       allowNull: false
     });
   }

--- a/util/db/migrations/20221007074355-remove-allow-null-false-on-return-date-columns.js
+++ b/util/db/migrations/20221007074355-remove-allow-null-false-on-return-date-columns.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.changeColumn('Returns', 'startDate', {
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('Returns', 'endDate', {
+      allowNull: true
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.changeColumn('Returns', 'endDate', {
+      allowNull: false
+    });
+
+    await queryInterface.changeColumn('Returns', 'startDate', {
+      allowNull: false
+    });
+  }
+};


### PR DESCRIPTION
 Bugfixes for https://github.com/Scottish-Natural-Heritage/Licensing/issues/1470

I had forgotten that there was a "No" licence used path that still needs to be saved to the database. As part of this I had to remove the `notNull` checks on the start and end date columns with a `changeColumn` migration.