### PR TITLE
feature/update-return-database-views

### DIFF
--- a/util/db/migrations/20230209143827-update-old-and-new-return-views.js
+++ b/util/db/migrations/20230209143827-update-old-and-new-return-views.js
@@ -26,7 +26,7 @@ if (process.env.NODE_ENV === 'production') {
         type: Sequelize.QueryTypes.RAW
       });
 
-      await queryInterface.sequelize.query('CREATE VIEW sfo_Returns AS SELECT * FROM sfo."Returns";', {
+      await queryInterface.sequelize.query('CREATE VIEW sfo_Returns AS SELECT * FROM sfo."OldReturns";', {
         type: Sequelize.QueryTypes.RAW
       });
     }

--- a/util/db/migrations/20230209143827-update-old-and-new-return-views.js
+++ b/util/db/migrations/20230209143827-update-old-and-new-return-views.js
@@ -1,0 +1,43 @@
+'use strict';
+const process = require('process');
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = {
+    async up(queryInterface, Sequelize) {
+      await queryInterface.sequelize.query('DROP VIEW sfo_Returns;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('CREATE VIEW sfo_Returns AS SELECT * FROM sfo."Returns";', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('CREATE VIEW sfo_OldReturns AS SELECT * FROM sfo."OldReturns";', {
+        type: Sequelize.QueryTypes.RAW
+      });
+    },
+
+    async down(queryInterface, Sequelize) {
+      await queryInterface.sequelize.query('DROP VIEW sfo_OldReturns;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('DROP VIEW sfo_Returns;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('CREATE VIEW sfo_Returns AS SELECT * FROM sfo."Returns";', {
+        type: Sequelize.QueryTypes.RAW
+      });
+    }
+  };
+} else {
+  module.exports = {
+    up() {
+      return Promise.resolve();
+    },
+    down() {
+      return Promise.resolve();
+    }
+  };
+}


### PR DESCRIPTION
Drops the exist `sfo_Returns` view and creates a new `sfo_Returns` view alongside an `sfo_OldReturns` view. Needed to allow Superset to access both the old style and new style returns data.

Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1730.