### PR TITLE
fixed code to save expiryDate to be 30 November

### DIFF
--- a/src/v2-router.js
+++ b/src/v2-router.js
@@ -66,16 +66,9 @@ v2router.get('/applications/:id', async (request, response) => {
  * @returns {Date} the calculated expiry date.
  */
 const calculateExpiryDate = () => {
-  let expiryDate;
   const currentYear = new Date().getFullYear();
 
-  if (new Date().getMonth() + 1 < 7) {
-    expiryDate = new Date(currentYear, 6, 1);
-  } else if (new Date().getMonth() + 1 < 12) {
-    expiryDate = new Date(currentYear, 10, 30);
-  } else {
-    expiryDate = new Date(currentYear + 1, 10, 30);
-  }
+  const expiryDate = new Date().getMonth() + 1 < 12 ? new Date(currentYear, 10, 30) : new Date(currentYear + 1, 10, 30);
 
   return expiryDate;
 };


### PR DESCRIPTION
This refactors the code so that if the date is before December of the current year it will set the expiry to the 30th of November however if the current date is December it will set the expiry to the 30th of November for the following year.

Issue: Scottish-Natural-Heritage/Licensing#1881