### PR TITLE
feature/npm-audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.3.1",
+        "axios": "^1.7.2",
         "express": "^4.18.1",
         "jsonwebtoken": "^8.5.1",
         "jwk-to-pem": "^2.0.5",
         "morgan": "^1.10.0",
         "naturescot-utils": "^1.2.0",
         "node-cron": "^3.0.2",
-        "notifications-node-client": "^5.1.1",
+        "notifications-node-client": "^8.1.0",
         "on-finished": "^2.3.0",
         "pg": "^8.6.0",
         "pg-hstore": "^2.3.4",
@@ -1107,9 +1107,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6012,21 +6012,43 @@
       }
     },
     "node_modules/notifications-node-client": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-5.2.3.tgz",
-      "integrity": "sha512-sjO/Pf4Mk/e2tbSUftUXZroDxAqENF1Ir8cAUK6jejPHCmOLoQLGzDOSUBh7ln0sMSbKO26XjGc9wRyzkRkobw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-8.1.0.tgz",
+      "integrity": "sha512-2NJqPEcvlFRxuPMMWqoVXVUDz9EWl8dQVAhnLfRdv61PaHMqIRiQTdwn2qge8sC3kAsLnJoTl0qxhwDUarkYsQ==",
       "dependencies": {
-        "axios": "^0.25.0",
-        "jsonwebtoken": "^8.2.1"
+        "axios": "^1.6.1",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.17.3",
+        "npm": ">=6.14.13"
       }
     },
-    "node_modules/notifications-node-client/node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+    "node_modules/notifications-node-client/node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
       }
+    },
+    "node_modules/notifications-node-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -10713,9 +10735,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -14457,21 +14479,35 @@
       "dev": true
     },
     "notifications-node-client": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-5.2.3.tgz",
-      "integrity": "sha512-sjO/Pf4Mk/e2tbSUftUXZroDxAqENF1Ir8cAUK6jejPHCmOLoQLGzDOSUBh7ln0sMSbKO26XjGc9wRyzkRkobw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-8.1.0.tgz",
+      "integrity": "sha512-2NJqPEcvlFRxuPMMWqoVXVUDz9EWl8dQVAhnLfRdv61PaHMqIRiQTdwn2qge8sC3kAsLnJoTl0qxhwDUarkYsQ==",
       "requires": {
-        "axios": "^0.25.0",
-        "jsonwebtoken": "^8.2.1"
+        "axios": "^1.6.1",
+        "jsonwebtoken": "^9.0.0"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.25.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+        "jsonwebtoken": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+          "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
           "requires": {
-            "follow-redirects": "^1.14.7"
+            "jws": "^3.2.2",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^7.5.4"
           }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jsonwebtoken": "^8.5.1",
     "jwk-to-pem": "^2.0.5",
     "naturescot-utils": "^1.2.0",
-    "notifications-node-client": "^5.1.1",
+    "notifications-node-client": "^8.1.0",
     "on-finished": "^2.3.0",
     "pg": "^8.6.0",
     "pg-hstore": "^2.3.4",
@@ -35,7 +35,7 @@
     "sqlite3": "^5.0.2",
     "winston": "^3.3.3",
     "node-cron": "^3.0.2",
-    "axios": "^1.3.1"
+    "axios": "^1.7.2"
   },
   "devDependencies": {
     "newman": "^6.0.0",


### PR DESCRIPTION
Updates the `axios` package to version 1.7.2 to fix a cross-site forgery vulnerability.

Updates the `notifications-node-client` package to version 8.1.0 to fix a cross-site forgery vulnerability.

Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/2157.