### PR TITLE
feature/16-update-premigrations-for-rds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # standard-forestry-operations-api
 
-Apply for a Standard Forestry Operations licence
+Apply for a Standard Forestry Operations licence.
 
 ## Develop
 

--- a/util/db/pre-migrations/20210823204833-sfo-ro-grant-to-user.js
+++ b/util/db/pre-migrations/20210823204833-sfo-ro-grant-to-user.js
@@ -18,6 +18,10 @@ if (process.env.NODE_ENV === 'production') {
         type: Sequelize.QueryTypes.RAW
       });
 
+      await queryInterface.sequelize.query('grant sfo to licensing;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
       await queryInterface.sequelize.query(
         'alter default privileges for role licensing, sfo in schema sfo grant select on tables to rosfo;',
         {
@@ -32,6 +36,10 @@ if (process.env.NODE_ENV === 'production') {
           type: Sequelize.QueryTypes.RAW
         }
       );
+
+      await queryInterface.sequelize.query('revoke sfo from licensing;', {
+        type: Sequelize.QueryTypes.RAW
+      });
 
       await queryInterface.sequelize.query('revoke select on schema sfo from rosfo;', {
         type: Sequelize.QueryTypes.RAW

--- a/util/db/pre-migrations/20220331101508-change-ro-sfo-password.js
+++ b/util/db/pre-migrations/20220331101508-change-ro-sfo-password.js
@@ -5,16 +5,24 @@ const config = require('../../../src/config/database.js').ssDatabase;
 if (process.env.NODE_ENV === 'production') {
   module.exports = {
     async up(queryInterface, Sequelize) {
-      return queryInterface.sequelize.query('ALTER ROLE rosfo WITH PASSWORD :roSfoPassword;', {
+      await queryInterface.sequelize.query('ALTER ROLE rosfo WITH PASSWORD :roSfoPassword;', {
         type: Sequelize.QueryTypes.RAW,
         replacements: {
           roSfoPassword: config.password
         }
       });
+
+      await queryInterface.sequelize.query('revoke sfo from licensing;', {
+        type: Sequelize.QueryTypes.RAW
+      });
     },
 
     async down(queryInterface, Sequelize) {
-      return queryInterface.sequelize.query("ALTER ROLE rosfo WITH PASSWORD 'override_this_value';", {
+      await queryInterface.sequelize.query('grant sfo to licensing;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query("ALTER ROLE rosfo WITH PASSWORD 'override_this_value';", {
         type: Sequelize.QueryTypes.RAW
       });
     }


### PR DESCRIPTION
Roles and permissions are configured slightly differently on an RDS than on a regular PostgreSQL install, with an `rds_superuser` role assigned to the default `licenisng` user - this role cannot run the `alter default privileges` command without first assigning the `sfo` role to `licensing`.

This PR updates the premigrations to temporarily set the `sfo` role on the `licensing` user, and then drop it after the read-only user is created.

Part of the investigation work on https://github.com/Scottish-Natural-Heritage/AWS-Cloud-Infrastructure-Review-Optimise-Standardise/issues/16.