### PR TITLE
feature/test-migrations-still-work

### DIFF
--- a/src/controllers/v2/test-migration.js
+++ b/src/controllers/v2/test-migration.js
@@ -1,0 +1,27 @@
+import database from '../../models/index.js';
+
+const {TestMigration} = database;
+
+const TestMigrationController = {
+  async create(testMigration) {
+    try {
+      const newTestMigrationTransaction = await database.sequelize.transaction(async (t) => {
+        const newTestMigration = await TestMigration.create(testMigration, {transaction: t});
+        return newTestMigration;
+      });
+      return newTestMigrationTransaction.id;
+    } catch {
+      return undefined;
+    }
+  },
+
+  async findOne(id) {
+    return TestMigration.findByPk(id);
+  },
+
+  async findAll() {
+    return TestMigration.findAll();
+  }
+};
+
+export {TestMigrationController as default};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -8,6 +8,7 @@ import Note from './note.js';
 import Returns from './returns.js';
 import OldReturns from './old-returns.js';
 import SettPhotos from './sett-photos.js';
+import TestMigration from './test-migration.js';
 
 const sequelize = new Sequelize(databaseConfig.database);
 
@@ -20,7 +21,8 @@ const database = {
   Revocation: Revocation(sequelize),
   Returns: Returns(sequelize),
   OldReturns: OldReturns(sequelize),
-  SettPhotos: SettPhotos(sequelize)
+  SettPhotos: SettPhotos(sequelize),
+  TestMigration: TestMigration(sequelize)
 };
 
 database.Application.hasMany(database.Sett);

--- a/src/models/test-migration.js
+++ b/src/models/test-migration.js
@@ -1,0 +1,33 @@
+'use strict';
+
+import Sequelize from 'sequelize';
+
+const {Model} = Sequelize;
+
+/**
+ * Build a TestMigration model.
+ *
+ * @param {Sequelize.Sequelize} sequelize A Sequelize connection.
+ * @returns {Sequelize.Model} An TestMigration model.
+ */
+const TestMigrationModel = (sequelize) => {
+  class TestMigration extends Model {}
+
+  TestMigration.init(
+    {
+      testColumn: {
+        type: Sequelize.TEXT
+      }
+    },
+    {
+      sequelize,
+      modelName: 'TestMigration',
+      timestamps: true,
+      paranoid: true
+    }
+  );
+
+  return TestMigration;
+};
+
+export {TestMigrationModel as default};

--- a/src/v2-router.js
+++ b/src/v2-router.js
@@ -10,6 +10,7 @@ import jsonConsoleLogger, {unErrorJson} from './json-console-logger.js';
 import config from './config/app.js';
 import {EmailService} from './services/email-service.js';
 import jwk from './config/jwk.js';
+import TestMigrationController from './controllers/v2/test-migration.js';
 
 const v2router = express.Router();
 
@@ -683,6 +684,39 @@ v2router.get('/applications/:id/login', async (request, response) => {
     token,
     loginLink
   });
+});
+
+/**
+ * GET Test endpoint.
+ */
+v2router.get('/test-migrations', async (request, response) => {
+  try {
+    const testMigrations = await TestMigrationController.findAll();
+
+    return response.status(200).send(testMigrations);
+  } catch (error) {
+    jsonConsoleLogger.error(unErrorJson(error));
+    return response.status(500).send({error});
+  }
+});
+
+/**
+ * POST Test endpoint.
+ */
+v2router.post('/test-migrations', async (request, response) => {
+  try {
+    const testMigration = request.body;
+
+    const newTestMigration = await TestMigrationController.create(testMigration);
+
+    if (newTestMigration === undefined) {
+      return response.status(500).send({message: `Could not create newTestMigration`});
+    }
+
+    return response.status(201).send({message: 'Test Write To DB Succeeded'});
+  } catch (error) {
+    return response.status(500).send({error});
+  }
 });
 
 // Allow an API consumer to retrieve the public half of our ECDSA key to

--- a/util/db/migrations/20250113080316-test-migration.js
+++ b/util/db/migrations/20250113080316-test-migration.js
@@ -1,0 +1,30 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('TestMigrations', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+        autoIncrement: true
+      },
+
+      testColumn: {
+        type: Sequelize.TEXT
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      deletedAt: {
+        type: Sequelize.DATE
+      }
+    });
+  },
+  async down(queryInterface) {
+    await queryInterface.dropTable('TestMigrations');
+  }
+};


### PR DESCRIPTION
Adds a new table and a couple of endpoints to test that after the migration to the new RDS any new migrations and any added tables will still be writable and function as expected.

Last bit of testing before issue https://github.com/Scottish-Natural-Heritage/AWS-Cloud-Infrastructure-Review-Optimise-Standardise/issues/30.