### PR TITLE
Upgrade Newman to work with Node 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "winston": "^3.3.3"
       },
       "devDependencies": {
-        "newman": "^6.0.0",
+        "newman": "^6.2.1",
         "nodemon": "^3.1.0",
         "prettier": "^2.3.1",
         "start-server-and-test": "^2.0.3",
@@ -209,6 +209,7 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
       "integrity": "sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==",
+      "deprecated": "Please update to a newer version.",
       "dev": true,
       "license": "MIT"
     },
@@ -1576,9 +1577,9 @@
       }
     },
     "node_modules/aws4": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.1.tgz",
-      "integrity": "sha512-u5w79Rd7SU4JaIlA/zFqG+gOiuq25q5VLyZ8E+ijJeILuTxVzZgp2CaGw/UTw6pXYN9XMO9yiqj/nEHmhTG5CA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6112,9 +6113,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
-      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==",
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -7065,9 +7066,9 @@
       "dev": true
     },
     "node_modules/newman": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/newman/-/newman-6.2.0.tgz",
-      "integrity": "sha512-CHo/wMv+Q9B3YcIJ18pdmY9XN9X8mc2hXso8yybeclV0BVPSFz1+P5vJELWg5DB/qJgxJOh+B+k+i9tTqfzcbw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/newman/-/newman-6.2.1.tgz",
+      "integrity": "sha512-Zq8Sr5GFF+OXs5yIbyglLMKMh1WNMjYVV0yZaSBZ+DIgQOIWcxT8QTfbrl/YUGrLyT4rjpu+yZ/Z+kozw79GEA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7083,10 +7084,10 @@
         "liquid-json": "0.3.1",
         "lodash": "4.17.21",
         "mkdirp": "3.0.1",
-        "postman-collection": "4.5.0",
+        "postman-collection": "4.4.0",
         "postman-collection-transformer": "4.1.8",
-        "postman-request": "2.88.1-postman.39",
-        "postman-runtime": "7.41.2",
+        "postman-request": "2.88.1-postman.34",
+        "postman-runtime": "7.39.1",
         "pretty-ms": "7.0.1",
         "semver": "7.6.3",
         "serialised-error": "1.1.3",
@@ -7973,9 +7974,9 @@
       }
     },
     "node_modules/postman-collection": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.5.0.tgz",
-      "integrity": "sha512-152JSW9pdbaoJihwjc7Q8lc3nPg/PC9lPTHdMk7SHnHhu/GBJB7b2yb9zG7Qua578+3PxkQ/HYBuXpDSvsf7GQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.4.0.tgz",
+      "integrity": "sha512-2BGDFcUwlK08CqZFUlIC8kwRJueVzPjZnnokWPtJCd9f2J06HBQpGL7t2P1Ud1NEsK9NHq9wdipUhWLOPj5s/Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7988,7 +7989,7 @@
         "mime-format": "2.0.1",
         "mime-types": "2.1.35",
         "postman-url-encoder": "3.0.5",
-        "semver": "7.6.3",
+        "semver": "7.5.4",
         "uuid": "8.3.2"
       },
       "engines": {
@@ -8063,16 +8064,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/postman-collection/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-collection/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/postman-request": {
-      "version": "2.88.1-postman.39",
-      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.39.tgz",
-      "integrity": "sha512-rsncxxDlbn1YpygXSgJqbJzIjGlHFcZjbYDzeBPTQHMDfLuSTzZz735JHV8i1+lOROuJ7MjNap4eaSD3UijHzQ==",
+      "version": "2.88.1-postman.34",
+      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.34.tgz",
+      "integrity": "sha512-GkolJ4cIzgamcwHRDkeZc/taFWO1u2HuGNML47K9ZAsFH2LdEkS5Yy8QanpzhjydzV3WWthl9v60J8E7SjKodQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@postman/form-data": "~3.1.1",
         "@postman/tough-cookie": "~4.1.3-postman.1",
-        "@postman/tunnel-agent": "^0.6.4",
+        "@postman/tunnel-agent": "^0.6.3",
         "aws-sign2": "~0.7.0",
         "aws4": "^1.12.0",
         "brotli": "^1.3.3",
@@ -8094,7 +8124,7 @@
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 6"
       }
     },
     "node_modules/postman-request/node_modules/qs": {
@@ -8108,50 +8138,57 @@
       }
     },
     "node_modules/postman-runtime": {
-      "version": "7.41.2",
-      "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.41.2.tgz",
-      "integrity": "sha512-efKnii+yBfqZMRjV5zFh4VXogLeZB58HmLkgT+/sZcjglth23wzp+QRlkl4nbgcL2SZX6e5cLI2/aG2Of3wMyg==",
+      "version": "7.39.1",
+      "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.39.1.tgz",
+      "integrity": "sha512-IRNrBE0l1K3ZqQhQVYgF6MPuqOB9HqYncal+a7RpSS+sysKLhJMkC9SfUn1HVuOpokdPkK92ykvPzj8kCOLYAg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@postman/tough-cookie": "4.1.3-postman.1",
         "async": "3.2.5",
-        "aws4": "1.13.1",
+        "aws4": "1.12.0",
         "handlebars": "4.7.8",
         "httpntlm": "1.8.13",
-        "jose": "5.6.3",
+        "jose": "4.14.4",
         "js-sha512": "0.9.0",
         "lodash": "4.17.21",
         "mime-types": "2.1.35",
         "node-forge": "1.3.1",
         "node-oauth1": "1.3.0",
         "performance-now": "2.1.0",
-        "postman-collection": "4.5.0",
-        "postman-request": "2.88.1-postman.39",
-        "postman-sandbox": "5.1.1",
+        "postman-collection": "4.4.0",
+        "postman-request": "2.88.1-postman.34",
+        "postman-sandbox": "4.7.1",
         "postman-url-encoder": "3.0.5",
         "serialised-error": "1.1.3",
         "strip-json-comments": "3.1.1",
         "uuid": "8.3.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=12"
       }
     },
+    "node_modules/postman-runtime/node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/postman-sandbox": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-5.1.1.tgz",
-      "integrity": "sha512-RfCTMwz3OaqhYYgtoe3VlHGiQl9hEmJ9sPh/XOlNcuvd/km6ARSFkKXFvQaLFsTHyXcHaqpInKaQSJi23uTynA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-4.7.1.tgz",
+      "integrity": "sha512-H2wYSLK0mB588IaxoLrLoPbpmxsIcwFtgaK2c8gAsAQ+TgYFePwb4qdeVcYDMqmwrLd77/ViXkjasP/sBMz1sQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "4.17.21",
-        "postman-collection": "4.5.0",
+        "postman-collection": "4.4.0",
         "teleport-javascript": "1.0.0",
-        "uvm": "3.0.0"
+        "uvm": "2.1.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=10"
       }
     },
     "node_modules/postman-url-encoder": {
@@ -8309,11 +8346,17 @@
       }
     },
     "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -10177,9 +10220,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.2.tgz",
-      "integrity": "sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
@@ -10368,17 +10411,24 @@
       }
     },
     "node_modules/uvm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uvm/-/uvm-3.0.0.tgz",
-      "integrity": "sha512-dATVpxsNfFBpHNdq6sy4/CV2UnoRbV8tvvkK0VrUPnm+o7dK6fnir4LEm8czeDdpbw2KKDKjIPcRSZY4AEwEZA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/uvm/-/uvm-2.1.1.tgz",
+      "integrity": "sha512-BZ5w8adTpNNr+zczOBRpaX/hH8UPKAf7fmCnidrcsqt3bn8KT9bDIfuS7hgRU9RXgiN01su2pwysBONY6w8W5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "flatted": "3.3.1"
+        "flatted": "3.2.6"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=10"
       }
+    },
+    "node_modules/uvm/node_modules/flatted": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
+      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "newman": "^6.0.0",
+    "newman": "^6.2.1",
     "nodemon": "^3.1.0",
     "prettier": "^2.3.1",
     "start-server-and-test": "^2.0.3",


### PR DESCRIPTION
I'm adding other services to the licensing-api and would like to upgrade Newman in line with the other projects.

Hopefully an uncontroversial change.