### PR TITLE
Proposal: ensure setts is at minimum an emply array.

### DIFF
--- a/src/v1-router.js
+++ b/src/v1-router.js
@@ -248,8 +248,8 @@ const cleanInput = (body) => {
 
     // We copy across the setts, cleaning them as we go.
     setts:
-      body.setts === undefined
-        ? undefined
+      !Array.isArray(body.setts)
+        ? []
         : body.setts.map((sett) => {
             return {
               // The number is just copied across.

--- a/src/v2-router.js
+++ b/src/v2-router.js
@@ -103,8 +103,8 @@ const cleanAppInput = (body) => {
 
     // We copy across the setts, cleaning them as we go.
     setts:
-      body.setts === undefined
-        ? undefined
+      !Array.isArray(body.setts)
+        ? []
         : body.setts.map((sett) => {
             return {
               // The number is just copied across.


### PR DESCRIPTION
There's the potential for an infinite look if `setts` is undefined on the incoming request body.

This may or may not be the best solution, just recording a proposed change for future consideration.

The point where the issue occurs is in `src/controllers/v2/application.js` line 283 (relative to commit `8eb95d1bf98282f747751ce50ca271175c4291df`)

 * `setts.map(async (jsonSett) => {` throws an exception because `setts` is undefined.
 * This means that `remainingAttempts--;` doesn't get called (10 attempts to find an unused ID - might need to raise this at some point?)
 * Therefore the request hangs in an infinite loop with no ID returned and the number of attempts remaining never decreasing
