### PR TITLE
feature/update-application-use-node-24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 # drop back to the non-privileged user for run-time
 WORKDIR /home/node
 USER node
 
 # tell node, et al to run in production mode
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 # copy in the package files so that we can install and build the project
 # dependencies
@@ -22,15 +22,15 @@ COPY --chown=node:node ./.secrets ./.secrets
 
 # these variables are for overriding but keep them consistent between image and
 # run
-ENV SFO_API_PORT 3003
-ENV SFO_API_PATH_PREFIX standard-forestry-operations-api
+ENV SFO_API_PORT=3003
+ENV SFO_API_PATH_PREFIX=standard-forestry-operations-api
 
 # these variables are for overriding and they only matter during run
-ENV LICENSING_DB_HOST override_this_value
-ENV LICENSING_DB_PASS override_this_value
-ENV SFO_DB_PASS override_this_value
-ENV SFO_NOTIFY_API_KEY override_this_value
-ENV RO_SFO_DB_PASS override_this_value
+ENV LICENSING_DB_HOST=override_this_value
+ENV LICENSING_DB_PASS=override_this_value
+ENV SFO_DB_PASS=override_this_value
+ENV SFO_NOTIFY_API_KEY=override_this_value
+ENV RO_SFO_DB_PASS=override_this_value
 
 # let docker know about our listening port
 EXPOSE $SFO_API_PORT

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "start-server-and-test start http://localhost:3003/standard-forestry-operations-api/v1/health nm:run"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Node.js 20 reached end-of-life at the end of April.

Updates the Dockerfile to use the `node:24-alpine` image for building and deploying, and updates the `engine` field in package.json to `24`.

Fixes the `LegacyKeyValueFormat` warning in the logs.